### PR TITLE
Remove Ad Banner and remove Disqus from blog pages

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -74,7 +74,7 @@
           <li><a href="{{site.github_url}}"><i class="fab fa-github"></i></a></li>
       </ul>
   </div>
-    <div class="add_widget">
+    <!-- <div class="add_widget">
      {% include add.html %}
-    </div>
+    </div> -->
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -53,16 +53,16 @@ layout: default
                         </div>
                     </div>
                 </div>
-                <div class="discus-comments mt-5">
+                <!-- <div class="discus-comments mt-5">
                 	<div id="disqus_thread"></div>
 					<script>
 
 
 					var disqus_config = function () {
-					 this.page.url = '{{site.url}}{{page.url}}';  
-					 this.page.identifier = '{{page.url}}'; 
+					 this.page.url = '{{site.url}}{{page.url}}';
+					 this.page.identifier = '{{page.url}}';
 					};
-					
+
 					(function() { // DON'T EDIT BELOW THIS LINE
 					var d = document, s = d.createElement('script');
 					s.src = 'https://zCore-netlify-com.disqus.com/embed.js';
@@ -72,7 +72,7 @@ layout: default
 					</script>
 					<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 					<script id="dsq-count-scr" src="//zCore-netlify-com.disqus.com/count.js" async></script>
-                </div>
+                </div> -->
             </div>
             <div class="col-lg-4">
               {% include sidebar.html %}


### PR DESCRIPTION

This PR addresses Issue #61 and removes the Ad Banner and the Disqus snippet that appears on blog pages. The ad banner is called by div class  add _ widget and is inherited through sidebar . html. Both are commented out not deleted in case of rendering on different device viewports 

![ad-banner](https://github.com/zCoreGroup/zcoregroup.github.io/assets/101219686/22447006-8c2c-4993-8b61-330d90471a32)