### PR TITLE
Updated Tags and Categories with frontmatter reformatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 .DS_Store
 .wakatime-project
 .vscode/settings.json
+.frontmatterizer.py

--- a/_config.yml
+++ b/_config.yml
@@ -108,10 +108,14 @@ tag_page_dir: tag
 tag_permalink_style: pretty
 
 jekyll-archives:
-  enabled: all
+  enabled:
+    - tags
+    - categories
   layout: category
   permalinks:
+    tag: '/tag/:name/'
     category: '/category/:name/'
+
 
 feed:
   collections:

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -47,23 +47,26 @@
         </div>
         {% endfor %}
     </div>
-    <div class="widget_sidebar_box tags_widget">
-        <div class="sidebar_widget_title">
-            <h3>Popular Tags</h3>
-        </div>
-        <div id="tag-cloud">
-         <ul class="tags_list">
+<div class="widget_sidebar_box tags_widget">
+    <div class="sidebar_widget_title">
+        <h3>Popular Tags</h3>
+    </div>
+    <div id="tag-cloud">
+        <ul class="tags_list">
             {% capture tags %}
-              {% for tag in site.tags %}
-                <li data-sort="{{ site.posts.size | minus: tag[1].size | prepend: '0000' | slice: -4, 4 }}">
-                   <a class="tag_1" href="/{{ site.tag_page_dir }}/{{ tag[0] | slugify: 'pretty' }}">{{ tag[0] }} <span> ({{ tag[1].size }})</span></a>
-                </li>
-              {% endfor %}
+                {% for tag in site.tags %}
+                    {% if tag[1].size >= 3 %}
+                        <li data-sort="{{ site.posts.size | minus: tag[1].size | prepend: '0000' | slice: -4, 4 }}">
+                            <a class="tag_1" href="/{{ site.tag_page_dir }}/{{ tag[0] | slugify: 'pretty' }}">{{ tag[0] }} <span> ({{ tag[1].size }})</span></a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
             {% endcapture %}
             {{ tags | split:'</li>' | sort | join:'</li>' }}
         </ul>
-      </div>
     </div>
+</div>
+
     <div class="widget_sidebar_box social_widget">
       <div class="sidebar_widget_title">
           <h3>Follow Us</h3>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,7 +17,7 @@ layout: default
                         <div class="row">
                             <div class="col-lg-6">
                                 <div class="tags_area">
-                                    <h4>Releted Tags</h4>
+                                    <h4>Related Tags</h4>
                                     {{page | tags | capitalize | replace: ",","  "}}
                                 </div>
                             </div>

--- a/_posts/2023-01-30-intorducing-zcore-group.md
+++ b/_posts/2023-01-30-intorducing-zcore-group.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Introducing zCore Group"
-tags: news
-categories: [announcements]
 author: alexis
-post_image: "/assets/images/logos/logo_3.webp"
+categories:
+- announcements
+- ZCG
+layout: post
+post_image: /assets/images/logos/logo_3.webp
+tags:
+- news
+title: Introducing zCore Group
 ---
 
 At zCore Group (zCG), our mission is to solve challenges by combining our deep understanding of business needs with collaborative innovation. We do this by building trusted partnerships with our clients to optimize their business outcomes. Our aspiration is to close the collaboration gap between technology and federal agencies, and provide valuable solutions to both.

--- a/_posts/2023-02-07-avoiding-tech-debt-in-fed-software-dev.md
+++ b/_posts/2023-02-07-avoiding-tech-debt-in-fed-software-dev.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Avoiding Technical Debt in Federal Software Development"
-tags: tech
-categories: [technology]
 author: bastos
-post_image: "/assets/images/blog/iceberg.webp"
+categories:
+- technology
+- software development
+layout: post
+post_image: /assets/images/blog/iceberg.webp
+tags:
+- tech
+title: Avoiding Technical Debt in Federal Software Development
 ---
 
 Technical debt is the process by which a software development project (or a project of a technical nature) starts to accumulate any number of technical tasks that have not been accomplished. This can sometimes occur when a project is “moving fast” to accomplish the mission and in some, if not most, cases the scope and complexity of this debt is known to the development team but not known by the product and or planning team.

--- a/_posts/2023-02-21-maximize-hcd-potential.md
+++ b/_posts/2023-02-21-maximize-hcd-potential.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Maximizing the Potential of Human Centered Design (HCD) in Software Development"
-tags: projects, hcd
-categories: [design]
 author: bastos
-post_image: "/assets/images/blog/hcd.png"
+categories:
+- design
+layout: post
+post_image: /assets/images/blog/hcd.png
+tags:
+- projects
+- hcd
+title: Maximizing the Potential of Human Centered Design (HCD) in Software Development
 ---
 
 Human Centered Design (HCD) is a people-centered approach to software development that prioritizes understanding the needs and experiences of its users over features. The goal is to develop solutions that solve the right problems by creating small and simple inventions. This process involves designing and prototyping applications in an agile development process.

--- a/_posts/2023-03-01-switching-to-github-from-jira.md
+++ b/_posts/2023-03-01-switching-to-github-from-jira.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Switching to GitHub from Jira: A Guide for Project Managers"
-tags: projects, github
-categories: [process]
 author: bastos
-post_image: "/assets/images/blog/issues-board.png"
+categories:
+- process
+layout: post
+post_image: /assets/images/blog/issues-board.png
+tags:
+- projects
+- github
+title: 'Switching to GitHub from Jira: A Guide for Project Managers'
 ---
 
 Program or Project Managers in the federal space are likely well-versed in the use of Jira, a tool used for tracking and managing project tasks. Jira is to PMs as GitHub Projects is to developers. Many developers prefer to live and work in GitHub due to direct access to code. In this post we explore how GitHub Projects can be used like Jira and why a switch may be beneficial for your team.

--- a/_posts/2023-03-15-zcore-website-update.md
+++ b/_posts/2023-03-15-zcore-website-update.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "zCore's Website Rebrand and Redesign with a focus on Insights"
-tags: news
-categories: [announcements]
 author: bastos
-post_image: "/assets/images/blog/new-website.png"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/new-website.png
+tags:
+- news
+title: zCore's Website Rebrand and Redesign with a focus on Insights
 ---
 
 We're excited to announce that [zCore](https://zcoregroup.com/), a contracting technology firm, has recently undergone a website rebrand and redesign. The new website is now focused on providing insights about technology and the federal contracting space, aimed at helping customers like us better understand the latest trends and developments in these areas.

--- a/_posts/2023-04-05-machine-learning-as-force-multiplier.md
+++ b/_posts/2023-04-05-machine-learning-as-force-multiplier.md
@@ -1,10 +1,16 @@
 ---
-layout: post
-title: "Machine Learing as a Force Multiplier"
-tags: ML,classification,prediction,interpretation,generation
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/machine-learning.jpeg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/machine-learning.jpeg
+tags:
+- ML
+- classification
+- prediction
+- interpretation
+- generation
+title: Machine Learing as a Force Multiplier
 ---
 
 Machine Learning (ML) is a powerful tool that can help organizations unlock valuable insights from their data. By using ML algorithms, businesses can automate tasks, make predictions, and identify patterns in large datasets that would be impossible for humans to do manually. In this blog post, we'll explore the four types of ML - classification, prediction, interpretation, and generation - and how they can be used to improve your organization's workflows.

--- a/_posts/2023-04-06-how-retailers-can-use-the-VAs-verification-APIs-to-validate-veterans.md
+++ b/_posts/2023-04-06-how-retailers-can-use-the-VAs-verification-APIs-to-validate-veterans.md
@@ -1,10 +1,15 @@
 ---
-layout: post
-title: "How Retailers Can Use The VAs Verification APIs to Validate Veterans"
-tags: APIs,verification,e-commerce,usability
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/retail-APIs.png"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/retail-APIs.png
+tags:
+- APIs
+- verification
+- e-commerce
+- usability
+title: How Retailers Can Use The VAs Verification APIs to Validate Veterans
 ---
 
 As retailers continue to seek ways to provide better services to their customers, the use of technology has become increasingly important. One area where technology can play a significant role is in the verification of veteran status. By using VA verification APIs, retailers can validate veterans and help them take advantage of veteran discounts, using real VA data. In this blog post, we will explore how retailers can use VA verification APIs to enhance the value, accessibility, and usability of commerce data for government, business, and the public.

--- a/_posts/2023-04-07-SQL-techniques-in-federal-projects.md
+++ b/_posts/2023-04-07-SQL-techniques-in-federal-projects.md
@@ -1,10 +1,14 @@
 ---
-layout: post
-title: "SQL Techniques in Federal Projects"
-tags: SQL,oracle,tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/SQL.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/SQL.jpg
+tags:
+- SQL
+- oracle
+- tech
+title: SQL Techniques in Federal Projects
 ---
 
 As businesses continue to collect more and more data, the importance of being able to effectively analyze and manipulate that data becomes increasingly important. SQL (Structured Query Language) has long been the go-to tool for managing and analyzing data, but many businesses are unaware of the advanced SQL techniques available to them.

--- a/_posts/2023-04-07-VA-Health-and-Benefits-app.md
+++ b/_posts/2023-04-07-VA-Health-and-Benefits-app.md
@@ -1,10 +1,14 @@
 ---
-layout: post
-title: "The Benefits of the VA's Health and Benefits App"
-tags: VA,health,tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/health-app.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/health-app.jpg
+tags:
+- VA
+- health
+- tech
+title: The Benefits of the VA's Health and Benefits App
 ---
 
 The VA: Health and Benefits app is a revolutionary tool designed to help veterans access the healthcare and benefits they need. With its advanced features and user-friendly interface, the app promises to be a game-changer in the world of veteran healthcare. In this article, we will explore the potential benefits and drawbacks of the VA: Health and Benefits app, as well as the role that zCore, a software development firm, can play in helping veterans and the VA implement this app more effectively.

--- a/_posts/2023-04-11-implementing-iFams.md
+++ b/_posts/2023-04-11-implementing-iFams.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Implementing iFams: The Complexities and Challenges of a Federal Agency ERP Data Migration"
-tags: tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/ifams.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/ifams.jpg
+tags:
+- tech
+title: 'Implementing iFams: The Complexities and Challenges of a Federal Agency ERP
+  Data Migration'
 ---
 
 The implementation of a new ERP system can be a daunting task for any organization, and the US Department of Veterans Affairs (VA) is no exception. With a need to replace their current Financial Management System (FMS) and several other smaller projects, the VA turned to CGI, a leading IT and business consulting services firm, to create a COTS (Commercial Off-The-Shelf) application called Momentum.

--- a/_posts/2023-04-12-GitHub-Projects-The-Ultimate-Tool.md
+++ b/_posts/2023-04-12-GitHub-Projects-The-Ultimate-Tool.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "GitHub Projects: The Ultimate Tool for Agile Project Management"
-tags: tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/git-projects.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/git-projects.jpg
+tags:
+- tech
+title: 'GitHub Projects: The Ultimate Tool for Agile Project Management'
 ---
 
 GitHub Projects is a reincarnation of the original GitHub, but with a new focus on project management. The objective of GitHub Projects is to put the control back in the teams' hands. The developers behind GitHub Projects wanted to create a tool that allows flexibility for methodology and let tasks flow without using methodology but still using the same kind of functionality.

--- a/_posts/2023-04-18-Python-Takes-the-Crown.md
+++ b/_posts/2023-04-18-Python-Takes-the-Crown.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Python Takes the Crown: How It Became the Top Computer Language"
-tags: tech,software
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/python.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/python.jpg
+tags:
+- tech
+- software
+title: 'Python Takes the Crown: How It Became the Top Computer Language'
 ---
 
 For many years, JavaScript has been the dominant programming language among software developers worldwide. However, in December 2021, Python rose to the top of the list of the most used programming languages. This is a significant milestone for Python, as it has been steadily gaining popularity over the past few years.

--- a/_posts/2023-04-19-aws-and-awsgovcloud.md
+++ b/_posts/2023-04-19-aws-and-awsgovcloud.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "AWS and AWS GovCloud: A Closer Look at Cloud Computing for Government Workloads"
-tags: tech,software
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/aws.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/aws.jpg
+tags:
+- tech
+- software
+title: 'AWS and AWS GovCloud: A Closer Look at Cloud Computing for Government Workloads'
 ---
 
 Are you familiar with Amazon Web Services (AWS)? If you're not, don't worry! I'm here to help you understand what AWS is, what it does, and how it can help you and your business. AWS is a cloud computing platform that provides a vast array of computing resources and services on demand over the internet. In simple terms, it's like having your own virtual data center, without the overhead costs and complexity of traditional IT infrastructure.

--- a/_posts/2023-04-24-DevOps.md
+++ b/_posts/2023-04-24-DevOps.md
@@ -1,10 +1,14 @@
 ---
-layout: post
-title: "Demystifying DevOps and DevSecOps: A Comprehensive Guide for Software Developers and Security Professionals"
-tags: tech,software
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/devops.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/devops.jpg
+tags:
+- tech
+- software
+title: 'Demystifying DevOps and DevSecOps: A Comprehensive Guide for Software Developers
+  and Security Professionals'
 ---
 
 DevOps and DevSecOps are two closely related methodologies that are transforming the way that software development and deployment is done. Both approaches have their own unique strengths and weaknesses, and each is suited to different types of software development projects.

--- a/_posts/2023-04-25-IaC.md
+++ b/_posts/2023-04-25-IaC.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "How Infrastructure as Code (IaC) is Revolutionizing DevOps and Government Contracting"
-tags: tech,software
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/IaC.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/IaC.jpg
+tags:
+- tech
+- software
+title: How Infrastructure as Code (IaC) is Revolutionizing DevOps and Government Contracting
 ---
 
 Infrastructure as Code (IaC) is a methodology that enables DevOps teams to automate and manage dynamic computing resources using code. It involves creating a single, trusted code base for an organization, which can be used to configure and manage complex application development environments. IaC can help organizations achieve greater efficiency, reliability, and security in their software development practices.

--- a/_posts/2023-04-26-main-pillars-of-software-development.md
+++ b/_posts/2023-04-26-main-pillars-of-software-development.md
@@ -1,10 +1,14 @@
 ---
-layout: post
-title: "Exploring the Main Pillars of Modern Software Development: From Cloud Computing to 5G Connectivity"
-tags: tech,software
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/sd.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/sd.jpg
+tags:
+- tech
+- software
+title: 'Exploring the Main Pillars of Modern Software Development: From Cloud Computing
+  to 5G Connectivity'
 ---
 
 In today's digital age, software development has become an integral part of modern businesses, with various technologies emerging to facilitate the process. These technologies have revolutionized the way software developers design, build, and deploy applications. In this blog post, we will explore the main pillars of modern software development, including cloud computing, microservices, blockchain, IoT, AI, augmented reality, the LCNC approach, and 5G connectivity. Additionally, we will discuss some of the leading programming tools and emerging concepts used in modern software development.

--- a/_posts/2023-04-27-AI-blog-post.md
+++ b/_posts/2023-04-27-AI-blog-post.md
@@ -1,10 +1,14 @@
 ---
-layout: post
-title: "Deterministic AI pseudocode"
-tags: tech,software
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/AI.jpg"
+categories:
+- announcements
+- technology
+layout: post
+post_image: /assets/images/blog/AI.jpg
+tags:
+- tech
+- software
+title: Deterministic AI pseudocode
 ---
 
 Deterministic AI pseudocode is a type of code that allows programmers to describe the steps a computer program will take to complete a task in a deterministic manner. This means that the output of the program will always be the same for a given input, making it an essential tool for software developers looking to create reliable and consistent programs.

--- a/_posts/2023-04-28-HS-first-AI.md
+++ b/_posts/2023-04-28-HS-first-AI.md
@@ -1,10 +1,14 @@
 ---
-layout: post
-title: "Exploring the Power of AI: The Department of Homeland Security's New Task Force for National Security"
-tags: tech,AI
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/HS.jpg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/HS.jpg
+tags:
+- tech
+- AI
+title: 'Exploring the Power of AI: The Department of Homeland Security''s New Task
+  Force for National Security'
 ---
 
 The Department of Homeland Security (DHS) has announced the establishment of its first-ever AI Task Force, aimed at exploring the potential of AI in the field of national security. This move comes as a response to the growing need for advanced technologies to counter emerging threats and stay ahead of the curve.

--- a/_posts/2023-05-04-networking.md
+++ b/_posts/2023-05-04-networking.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Building Relationships for Success: The Importance of Networking in SDVOSB Government Contracting"
-tags: networking
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/networking.jpeg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/networking.jpeg
+tags:
+- networking
+title: 'Building Relationships for Success: The Importance of Networking in SDVOSB
+  Government Contracting'
 ---
 
 Networking is a critical aspect of business growth and success, and nowhere is this more evident than in the world of government contracting. For companies like zCore Group (ZCG), a Service-Disabled Veteran-Owned Small Business (SDVOSB) specializing in IT and management consulting, networking is essential to building relationships and winning new contracts.

--- a/_posts/2023-05-05-AI-in-health.md
+++ b/_posts/2023-05-05-AI-in-health.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "AI in Healthcare: Pros and Cons of a Revolutionizing Technology"
-tags: tech,health
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/health.jpg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/health.jpg
+tags:
+- tech
+- health
+title: 'AI in Healthcare: Pros and Cons of a Revolutionizing Technology'
 ---
 
 As the medical field continues to evolve, so does the role of artificial intelligence (AI). AI has the potential to revolutionize healthcare in a myriad of ways, from improving diagnosis and treatment to enhancing patient outcomes and reducing healthcare costs. However, as with any new technology, there are both pros and cons to its use in medicine.

--- a/_posts/2023-05-16-complexities-blog-post.md
+++ b/_posts/2023-05-16-complexities-blog-post.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Navigating the Complexities: Climate Risks, Foreign Influence, and Cybersecurity Measures for Contractors"
-tags: contracting
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/Climate-system.jpeg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/Climate-system.jpeg
+tags:
+- contracting
+title: 'Navigating the Complexities: Climate Risks, Foreign Influence, and Cybersecurity
+  Measures for Contractors'
 ---
 
 Introduction:

--- a/_posts/2023-05-17-jira-confluence.md
+++ b/_posts/2023-05-17-jira-confluence.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "Streamlining Project Management and Collaboration with Jira and Confluence"
-tags: tech
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/jira.jpeg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/jira.jpeg
+tags:
+- tech
+title: Streamlining Project Management and Collaboration with Jira and Confluence
 ---
 
 Effective project management and seamless collaboration are crucial elements for the success of any team or organization. To tackle these challenges, Atlassian has developed two powerful software tools: Jira and Confluence. Jira serves as a comprehensive issue tracking and project management solution, while Confluence acts as a collaboration and knowledge sharing platform. In this blog post, we will explore the features and benefits of Jira and Confluence and how they can streamline your project management and enhance team collaboration.

--- a/_posts/2023-05-18-VAEC-Migration.md
+++ b/_posts/2023-05-18-VAEC-Migration.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: " Migrating to VA Enterprise Cloud: What You Need to Know"
-tags: tech
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/migrate.jpeg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/migrate.jpeg
+tags:
+- tech
+title: ' Migrating to VA Enterprise Cloud: What You Need to Know'
 ---
 
 In a constant pursuit of enhanced user experience and improved security measures, the Department of Veterans Affairs (VA) is embarking on a significant migration journey. On May 26, 2023, the VA OIT DevOps Tools Team (DOTS) will bid farewell to MAX.GOV hosting and migrate the VA's Jira and Confluence platforms to the VA Enterprise Cloud (VAEC), DevOps Tools Enclave (DTE). This blog post aims to provide you with all the essential information regarding this migration and what you, as a user, need to know.

--- a/_posts/2023-05-19-pipeline.md
+++ b/_posts/2023-05-19-pipeline.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: " Mastering the Art of Building an Effective Pipeline with Federal Contracts"
-tags: business
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/line.jpg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/line.jpg
+tags:
+- business
+title: ' Mastering the Art of Building an Effective Pipeline with Federal Contracts'
 ---
 
 In the world of business, securing federal contracts can be a game-changer for growth and success. However, building a robust pipeline that consistently delivers the right opportunities requires careful planning and strategic execution. In this blog post, we will explore the intricacies of constructing a highly effective pipeline, discussing key elements such as opportunity identification, pipeline creation, and the utilization of tools and intelligence. Brace yourself for a journey through the realms of perplexity and burstiness as we unravel the secrets to maximizing your chances of securing lucrative federal contracts.

--- a/_posts/2023-05-22-monday-motivation.md
+++ b/_posts/2023-05-22-monday-motivation.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "Unleashing the Monday Motivation Magic: 5 Epic Ways to Fuel Your Workweek!"
-tags: motivation
-categories: [announcements]
 author: mackenzie
-post_image: "/assets/images/blog/motivation.jpg"
+categories:
+- announcements
+layout: post
+post_image: /assets/images/blog/motivation.jpg
+tags:
+- motivation
+title: 'Unleashing the Monday Motivation Magic: 5 Epic Ways to Fuel Your Workweek!'
 ---
 
 Ah, Mondays, the enigmatic portals that transport us from the tranquility of the weekend to the bustling world of work. As we navigate this transition, it's crucial to arm ourselves with an arsenal of motivation, ensuring that we charge into the week with vigor and purpose. In this blog post, we'll explore five mind-bending strategies that promise to infuse your Mondays with a delightful concoction of perplexity and burstiness, elevating your work game to extraordinary heights. Brace yourselves for a rollercoaster ride of inspiration!

--- a/_posts/2023-05-23-federal-workspace.md
+++ b/_posts/2023-05-23-federal-workspace.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "Embracing Change: The Ever-Evolving Federal Workspace"
-tags: federal
-categories: [process]
 author: mackenzie
-post_image: "/assets/images/blog/change.jpg"
+categories:
+- process
+layout: post
+post_image: /assets/images/blog/change.jpg
+tags:
+- federal
+title: 'Embracing Change: The Ever-Evolving Federal Workspace'
 ---
 
 The federal workspace has long been a hub of innovation, policy-making, and transformative initiatives. As we delve into the captivating realm of this dynamic environment, we uncover a tapestry of ideas, challenges, and opportunities that constantly shape its landscape. In this blog post, we'll explore a random topic that currently engrosses the federal workspace, unearthing its perplexity and reveling in the burstiness that characterizes human ingenuity.

--- a/_posts/2023-05-24-Alteryx-blog-post.md
+++ b/_posts/2023-05-24-Alteryx-blog-post.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "Unlocking the Power of Data with Alteryx: Revolutionizing Analytics and Automation"
-tags: tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/tool.png"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/tool.png
+tags:
+- tech
+title: 'Unlocking the Power of Data with Alteryx: Revolutionizing Analytics and Automation'
 ---
 
 In today's data-driven world, organizations are constantly seeking innovative tools to streamline their analytical processes and drive data-driven decision-making. One such tool that has gained significant popularity is Alteryx, a self-service analytic software. With its powerful data transformation toolkit and user-friendly interface, Alteryx empowers users to tackle complex data tasks with ease. In this blog post, we will explore the capabilities of Alteryx, its benefits for different user roles, and how zCore Group can leverage it to help our clients and partners.

--- a/_posts/2023-05-25-government-tech.md
+++ b/_posts/2023-05-25-government-tech.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Exploring the Complexity of Government Technology Adoption"
-tags: tech,government
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/gov-technology.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/gov-technology.jpg
+tags:
+- tech
+- government
+title: Exploring the Complexity of Government Technology Adoption
 ---
 
 The intricate relationship between technology and the public sector has long been a subject of discussion. As the digital revolution continues to reshape our world, governments are faced with the challenge of adopting technology to improve service provision. However, unlike the private sector, government entities have been historically slower in embracing technological advancements. In this blog post, we will delve into the perplexing realm of government technology adoption, analyzing the reasons behind this sluggishness and the potential benefits and risks associated with integrating technology into public services.

--- a/_posts/2023-05-26-Veterans-Affairs-AI.md
+++ b/_posts/2023-05-26-Veterans-Affairs-AI.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Unleashing the Power of AI: The Department of Veterans Affairs' Visionary Strategy"
-tags: tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/va-ai.jpeg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/va-ai.jpeg
+tags:
+- tech
+title: 'Unleashing the Power of AI: The Department of Veterans Affairs'' Visionary
+  Strategy'
 ---
 
 In an era of rapid technological advancements, the Department of Veterans Affairs (VA) is embracing the potential of Artificial Intelligence (AI) to revolutionize its services and enhance the well-being of our nation's veterans. The VA's AI Strategy, informed by national initiatives and legislation, aims to harness the power of AI capabilities for the benefit of veterans and society as a whole. By leveraging its extensive resources and network, the VA seeks to become a hub for AI innovation, ensuring that veterans receive the best possible care and support.

--- a/_posts/2023-05-30-sdvosb-blog-post.md
+++ b/_posts/2023-05-30-sdvosb-blog-post.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "Small Businesses in the Federal Workspace: Unleashing Opportunities with SDVOSBs"
-tags: business
-categories: [business]
 author: mackenzie
-post_image: "/assets/images/blog/small.jpg"
+categories:
+- business
+layout: post
+post_image: /assets/images/blog/small.jpg
+tags:
+- business
+title: 'Small Businesses in the Federal Workspace: Unleashing Opportunities with SDVOSBs'
 ---
 
 In the expansive realm of the federal workspace, small businesses have emerged as vital players, injecting dynamism, innovation, and adaptability into government operations. Their significance cannot be overstated, as they contribute to a vibrant ecosystem that fuels economic growth and provides exceptional value to both federal agencies and the broader society. In this blog post, we delve into the importance of small businesses in the federal workspace, shedding light on the benefits they bring and the transformative role they play. We also explore the significance of Service-Disabled Veteran-Owned Small Businesses (SDVOSBs) and their unique contributions. As a leading SDVOSB, zCore Group exemplifies the potential of such businesses, delivering cutting-edge IT management consulting solutions to federal agencies.

--- a/_posts/2023-05-31-supply-chain-tech-blog-post.md
+++ b/_posts/2023-05-31-supply-chain-tech-blog-post.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "Revolutionizing Government Supply Chain Management with Technology"
-tags: technology
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/supply.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/supply.jpg
+tags:
+- technology
+title: Revolutionizing Government Supply Chain Management with Technology
 ---
 
 In today's fast-paced world, effective supply chain management is vital for the smooth functioning of any organization. While the private sector has long embraced technology to enhance their supply chains, the government sector has sometimes lagged behind in adopting modern solutions. However, the potential benefits of integrating technology into government supply chain management are immense. From improving efficiency and transparency to enhancing decision-making capabilities, technology holds the key to revolutionizing the way the government manages its supply chains.

--- a/_posts/2023-06-02-technologies-evolution-blog.md
+++ b/_posts/2023-06-02-technologies-evolution-blog.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "The Evolving Landscape of Government Contracting: Navigating Emerging Technologies with zCore Group"
-tags: tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/artificial.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/artificial.jpg
+tags:
+- tech
+title: 'The Evolving Landscape of Government Contracting: Navigating Emerging Technologies
+  with zCore Group'
 ---
 
 Government contracting has always been subject to change, adapting to the demands of an ever-evolving landscape. In recent years, emerging technologies such as artificial intelligence (AI), blockchain, and cybersecurity have taken center stage, transforming the way contracts are awarded, executed, and managed. As contractors seek new avenues for growth and success, understanding the potential opportunities that lie within these technologies becomes paramount. In this blog post, we delve into the impact of emerging trends and technologies on government contracting, explore real-world examples of successful implementations, and highlight how zCore Group can help clients and partners navigate this transformative era.

--- a/_posts/2023-06-05-VA’s-API-Platform.md
+++ b/_posts/2023-06-05-VA’s-API-Platform.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "VA’s API Platform: Seamless and Secure Access to VA Data for Veterans, Their Families, and Advocates"
-tags: tech,
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/VA API'S.jpg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/VA API'S.jpg
+tags:
+- tech
+title: 'VA’s API Platform: Seamless and Secure Access to VA Data for Veterans, Their
+  Families, and Advocates'
 ---
 
 Planning a vacation has never been easier. With just a few clicks, you can find hundreds of flights tailored to your needs. This convenience is made possible by Application Programming Interfaces (APIs), which play a crucial role in allowing apps and platforms to access, share, and control data across the web. APIs effortlessly compile information from various sources and present it to users in one centralized location, saving time and effort. Just as APIs simplify travel planning, the Department of Veterans Affairs (VA) has harnessed their power to improve the connection between Veterans and VA services.

--- a/_posts/2023-06-1-the-VA-blog-post.md
+++ b/_posts/2023-06-1-the-VA-blog-post.md
@@ -1,10 +1,12 @@
 ---
-layout: post
-title: "The VA and Government Contracting: Unveiling the Symbiotic Partnership"
-tags: VA
-categories: [information]
 author: mackenzie
-post_image: "/assets/images/blog/va.jpg"
+categories:
+- information
+layout: post
+post_image: /assets/images/blog/va.jpg
+tags:
+- VA
+title: 'The VA and Government Contracting: Unveiling the Symbiotic Partnership'
 ---
 
 The Department of Veterans Affairs (VA) stands as a beacon of hope for those who have selflessly served their nation. Behind the scenes, however, lies a complex web of operations and partnerships that enable the VA to fulfill its mission effectively. Among these partnerships, government contracting emerges as a crucial force, seamlessly intertwining with the VA's operations to enhance its capacity to serve veterans and their families. In this article, we delve into the importance of government contracting for the VA, exploring the process and shedding light on the invaluable role it plays.

--- a/_posts/2023-06-14-GAO-findings-post.md
+++ b/_posts/2023-06-14-GAO-findings-post.md
@@ -1,12 +1,15 @@
 ---
-layout: post
-title: "Observations on IT Contracting Trends and Management Oversight at the Department of Veterans Affairs"
-tags: contracting,VA
-categories: [contracting]
 author: mackenzie
-post_image: "/assets/images/blog/GAO-analysis.png"
+categories:
+- contracting
+layout: post
+post_image: /assets/images/blog/GAO-analysis.png
+tags:
+- contracting
+- VA
+title: Observations on IT Contracting Trends and Management Oversight at the Department
+  of Veterans Affairs
 ---
-
 
 The efficient management of information technology (IT) systems is crucial for the Department of Veterans Affairs (VA) to provide benefits and healthcare services to millions of veterans and their families. The VA heavily relies on IT systems and has obligated over $25 billion for IT procurement between fiscal years 2017 and 2021, making it one of the largest IT spenders among federal agencies. However, the Government Accountability Office (GAO) has identified concerning trends in IT contracting and management oversight within the VA.
 

--- a/_posts/2023-06-15-AWS-Summit-blog-post.md
+++ b/_posts/2023-06-15-AWS-Summit-blog-post.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "zCore's AWS Summit Washington DC 2023 recap "
-tags: tech,AWS
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/summit-cover.jpeg"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/summit-cover.jpeg
+tags:
+- tech
+- AWS
+title: 'zCore''s AWS Summit Washington DC 2023 recap '
 ---
 
 June 7-8th, we had the incredible opportunity to attend the AWS Summit in Washington D.C. It was an event where industry professionals converged to discuss how Amazon Web Services (AWS) is transforming the public sector and tackling the challenges of today's rapidly changing world. The summit offered valuable insights into driving culture change, digital transformation, and infrastructure modernization. We were eager to explore and learn, and we returned with a plethora of knowledge to share. So let's dive into the key takeaways from the seminars we attended.

--- a/_posts/2023-06-16-GitHub-Apps.md
+++ b/_posts/2023-06-16-GitHub-Apps.md
@@ -1,10 +1,13 @@
 ---
-layout: post
-title: "Extending GitHub with Custom Apps: Unlocking the Power of Granularity and Ownership"
-tags: tech
-categories: [technology]
 author: mackenzie
-post_image: "/assets/images/blog/GitHub-Apps.png"
+categories:
+- technology
+layout: post
+post_image: /assets/images/blog/GitHub-Apps.png
+tags:
+- tech
+title: 'Extending GitHub with Custom Apps: Unlocking the Power of Granularity and
+  Ownership'
 ---
 
 GitHub, the leading platform for version control and collaboration, offers a range of powerful features and integrations. Among these are GitHub Apps, which provide a unique way to extend GitHub's functionality and enhance development workflows. In this blog post, we will delve into the world of GitHub Apps, exploring their capabilities, authentication methods, and the advantages they offer over regular user accounts.

--- a/case_details.html
+++ b/case_details.html
@@ -121,7 +121,7 @@ title: "Case Details"
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="tags_area">
-                                <h4>Releted Tags</h4>
+                                <h4>Related Tags</h4>
                                 <ul>
                                     <li><a href="#">Travel</a></li>
                                     <li><a href="#">Lifestyle</a></li>

--- a/frontmatterizer.py
+++ b/frontmatterizer.py
@@ -1,0 +1,30 @@
+import os
+import frontmatter
+
+# Directory containing the markdown files to be updated. This concept can be extended to any files in the repo that use frontmatter and need to be updated.
+dir_path = "_posts"
+
+# Iterate over all files in the directory
+for filename in os.listdir(dir_path):
+    if filename.endswith(".md"):
+        filepath = os.path.join(dir_path, filename)
+
+        # Then load the file to be read
+        with open(filepath, 'r', encoding='utf8') as f:
+            post = frontmatter.load(f)
+
+        # Then this update tags and categories to use the correct format
+        if 'tags' in post.keys():
+            if isinstance(post['tags'], str):
+                post['tags'] = [tag.strip() for tag in post['tags'].split(',')]
+        if 'categories' in post.keys():
+            if isinstance(post['categories'], str):
+                post['categories'] = [category.strip()
+                                      for category in post['categories'].split(',')]
+
+        # Writes the file back to the disk / directory
+        with open(filepath, 'w', encoding='utf8') as f:
+            f.write(frontmatter.dumps(post))
+# Path: frontmatterizer.py ends
+# To run this script, run the following command in the terminal:
+# $ python frontmatterizer.py


### PR DESCRIPTION
This PR resolves Issues #134, #135, #136 by reformatting the frontmatter of the markdown files with a Python script. The result is that the Tag cloud and Categories cloud no longer displays concatenated tags that overrun the widget box. Ordering and viewing by tags and categories now functions from the UI.

Demo: This PR fixes the tags and categories issues on Insights / blogs https://clipchamp.com/watch/n0YKZvSwfKJ