### PR TITLE
Fixes missing blog image thumbs in the Insights footer element

### DIFF
--- a/_includes/footer_2.html
+++ b/_includes/footer_2.html
@@ -41,10 +41,9 @@
                                         {% for post in site.posts limit:2 %}
                                         <div class="col-lg-6"> <!-- Add a column for each post -->
                                             <div class="news_single">
-<div class="news_thumb">
-    <img src="{{ post.post_image | relative_url }}" class="img-fluid" alt="">
-</div>
-
+                                                <div class="news_thumb">
+                                                    <img src="{{ post.post_image | relative_url }}" class="img-fluid" alt="">
+                                                </div>
                                                 <div class="news_link">
                                                     <h3>
                                                         <a href="{{ post.url | relative_url }}">

--- a/_includes/footer_2.html
+++ b/_includes/footer_2.html
@@ -41,9 +41,10 @@
                                         {% for post in site.posts limit:2 %}
                                         <div class="col-lg-6"> <!-- Add a column for each post -->
                                             <div class="news_single">
-                                                <div class="news_thumb">
-                                                    <img src="{{ post.image | relative_url }}" class="img-fluid" alt="">
-                                                </div>
+<div class="news_thumb">
+    <img src="{{ post.post_image | relative_url }}" class="img-fluid" alt="">
+</div>
+
                                                 <div class="news_link">
                                                     <h3>
                                                         <a href="{{ post.url | relative_url }}">


### PR DESCRIPTION
This PR resolves Issue #159, tracking the missing blog thumbnails in the Insights footer that is used on several pages. The footer element is found in _includes/footer_2 and the change is made at lines 44-46, by calling 'post_image.'