### PR TITLE
Revert "Fixes applied to the hamburger navigation menu"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: "zCoreGroup - Bleeding Edge Government Software Contracting"
 description: >- # this means to ignore newlines until "baseurl:"
   zCore Group (zCG) is consulting firm specializing in business and IT consulting. Our business consulting focuses on improving operational efficiency and business processes. zCG's IT consulting leverages automation in coding for our partner's solution.
-baseurl: "/zcoregroup.github.io" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://zcoregroup.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 phone_number: "(571) 228-2803"
 email: "connect@zcoregroup.com"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,9 +1,8 @@
  - text: Home
-   url: "/"
+   url: ""
 
  - text: Solutions
-   url: "/solutions"
-
+   url: "solutions"
   #  dropdown:
   #   - text: "Portfolios 01"
   #     url: "portfolios_1"
@@ -15,22 +14,17 @@
   #     url: "case_details"
 
  - text: "Insights"
-   url: "/blog"
-
+   url: "blog"
 
  - text: Careers
-   url: "/careers"
-
+   url: "careers"
    dropdown:
     - text: "About"
-      url: "/about"
-
+      url: "about"
     - text: "Team"
-      url: "/team"
-
+      url: "team"
     - text: "Join"
-      url: "/careers"
-
+      url: "careers"
 
  - text: "Contact"
-   url: "/contact"
+   url: "contact"

--- a/_includes/mobile_menu.html
+++ b/_includes/mobile_menu.html
@@ -15,7 +15,7 @@
         </div>
         <div class="sidenav_menu">
             <div class="times_icon">
-                <a href="/home/" class="menu_icon"><i class="far fa-times"></i></a>
+                <a href="#" class="menu_icon"><i class="far fa-times"></i></a>
             </div>
             <div class="brand_logo text-center">
                 <a href="{{site.url}}" class="logo"><img src="{{site.site_logo_two}}" alt="{{site.title}}"/></a>

--- a/_includes/mobile_navigation.html
+++ b/_includes/mobile_navigation.html
@@ -4,11 +4,11 @@
 {% for navigation in site.data.navigation %}
 
     <li>
-        <a href="{{ site.baseurl }}{{navigation.url}}">{{navigation.text}}  {% if navigation.dropdown %} <span><i class="far fa-angle-down"></i></span> {% endif %}</a>
+        <a href="{{navigation.url}}">{{navigation.text}}  {% if navigation.dropdown %} <span><i class="far fa-angle-down"></i></span> {% endif %}</a>
         {% if navigation.dropdown %}
             <ul class="sidebar-submenu">
               {% for dropdown in navigation.dropdown %}
-                <li><a href="{{ site.baseurl }}{{dropdown.url}}">{{dropdown.text}}</a></li>
+                <li><a href="{{dropdown.url}}">{{dropdown.text}}</a></li>
               {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
Reverts zCoreGroup/zcoregroup.github.io#171

When I ran jekyll build on `main` after this merge, the site was not rendering. I believe this behavior is coming from _config.yml and the baseurl being set to "/zcore.github.io" but it should be null or # 