### PR TITLE
Implement HTML Meta Refresh Redirect for 404 Page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,17 +1,10 @@
----
-layout: default
----
-{% include header_2.html %}
-<div class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="page-wrapper text-center py-5 my-5">
-          <h1>404</h1>
-          <p><strong>Page not found :(</strong></p>
-          <p>The requested page could not be found.</p>
-          <a href="{{site.url}}">Go Back Home</a>
-      </div>
-    </div>
-  </div>
-</div>
-{% include footer.html %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=/" />
+</head>
+<body>
+    <p>Page not found! Redirecting to the home page...</p>
+</body>
+</html>
+


### PR DESCRIPTION
This PR introduces a change to our 404 error page by implementing a meta refresh redirect to the root URL of our site.

Details:

The HTML file for the 404 error page has been updated with a <meta> tag in the <head> section that will cause any visitor who lands on this page to be immediately redirected to the root ("/") of our site. Here is the added code:

```html
<meta http-equiv="refresh" content="0; url=/" />
```

This "0" indicates that there is no delay before the redirection.

Impact:

While this solution doesn't provide a server-side, permanent (301) redirect due to HTML limitations, it provides a functional solution for redirecting users who happen upon a 404 error back to the main site.

![Screenshot 2023-07-10 at 10 13 34 AM](https://github.com/zCoreGroup/zcoregroup.github.io/assets/1518708/352a8fb2-f45e-4f40-9fcd-9b020696dc96)


