### PR TITLE
Remove background color for teamInfo h3

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -508,7 +508,6 @@
         font-size: 24px;
         line-height: 30px;
         color: #000;
-        background-color: #fff;
     }
 
     @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
- Remove background color for `<h3>` tag on home page team members

![image](https://github.com/zCoreGroup/zcoregroup.github.io/assets/20588863/f12365dc-e622-4f89-b164-97072870ddd2)
