### PR TITLE
Fix Text Color on ServiceBoxes on Home and Grid Layout

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -12,8 +12,8 @@
                             </div>
                             <div class="service_info">
                                 <h1>Mission</h1>
-                                <p>To solve challenges by combining business understanding and collaborative
-                                    modernization.
+                                <p>
+                                    To tackle challenges with business insight and collaborative modernization.
                                 </p>
                             </div>
                         </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2853,7 +2853,7 @@ textarea.form_control {
     height: 100%;
 }
 
-.about_service_box:hover .overlay .service_info h4,
+.about_service_box:hover .overlay .service_info h1,
 .about_service_box:hover .overlay .service_info p {
     color: #fff;
 }


### PR DESCRIPTION
- Fixed an issue when hovering over the service boxes on the home page. The title was displayed in black instead of white.
- Fixed an issue where the service boxes on the home page did not keep their 2x2 grid layout at a specific breakpoint.

Grid Layout Bug
![Screenshot 2023-12-18 at 1 56 58 PM](https://github.com/zCoreGroup/zcoregroup.github.io/assets/20588863/ab924b1b-9d94-4345-ade7-2bb5e3536a89)
<br>

Text Color Bug
![Screenshot 2023-12-18 at 2 05 32 PM](https://github.com/zCoreGroup/zcoregroup.github.io/assets/20588863/7b7b9118-943e-4d0c-b8a7-8d02e8161874)


Grid Layout and Text Color Fix
![Screenshot 2023-12-18 at 2 04 02 PM](https://github.com/zCoreGroup/zcoregroup.github.io/assets/20588863/81ce3c34-a8a5-41de-862a-9700aaab2fbe)


