### PR TITLE
Add Google Analytics gtag to layout HTML pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ _site
 .jekyll-metadata
 Gemfile.lock
 .DS_Store
-.wakatime-project
 .vscode/settings.json
 .frontmatterizer.py
 .idea
+.cursor
+.qodo

--- a/README.md
+++ b/README.md
@@ -101,4 +101,22 @@ This will create a page that uses the layout found in _layouts/page.html and set
 ===============================================================================
 ### [Kanban](https://github.com/orgs/zCoreGroup/projects/1/views/2)
 
-### © 2023 [zCore Group](https://zcoregroup.com)
+### Google Analytics
+- [ ] Add Google Analytics to the website's HTML pages
+  - HTML pages are located in the _includes/ directory
+- [ ] Add Google Tag Manager to the website
+- [ ] Add Google Optimize to the website
+
+Uncomment out and add this tag to the HTML pages on the website that you want to track:
+
+<!-- Google tag (gtag.js) -->
+<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-JNX8SMN6KY"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-JNX8SMN6KY');
+</script> -->
+
+### © 2025 [zCore Group](https://zcoregroup.com)

--- a/_layouts/careers.html
+++ b/_layouts/careers.html
@@ -6,6 +6,15 @@ pagination:
 
 ---
 {% include header_2.html %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JNX8SMN6KY"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-JNX8SMN6KY');
+</script>
 <script type="application/ld+json">
     {% include career.jsonld %}
 </script>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -5,6 +5,15 @@ pagination:
   enabled: true
 ---
 {% include header_2.html %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JNX8SMN6KY"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-JNX8SMN6KY');
+</script>
 {% include page_header_2.html %}
 <div class="container my-5">
 	{% include post_loop_three.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,17 @@
     <link rel="stylesheet" href="{{relative_url}}/assets/css/magnific-popup.css">
     <link rel="stylesheet" href="{{relative_url}}/assets/css/style.css">
     <link rel="stylesheet" href="{{relative_url}}/assets/css/responsive.css">
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JNX8SMN6KY"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-JNX8SMN6KY');
+    </script>
+
 </head>
 <body>
 <!-- Start Preloader Area -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,6 +3,15 @@ layout: default
 ---
 
 {% include header_2.html %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JNX8SMN6KY"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-JNX8SMN6KY');
+</script>
 <script type="application/ld+json">
     {% include page.jsonld %}
   </script>

--- a/_layouts/solution.html
+++ b/_layouts/solution.html
@@ -3,6 +3,15 @@ layout: default
 title: Tailored Solutions
 ---
 {% include header.html %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JNX8SMN6KY"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-JNX8SMN6KY');
+</script>
 {% include page_header_2.html %}
 <!-- Start zCore_Solutions single page section -->
 <section class="zCore_it_service zCore_it_service_1 section_padding">


### PR DESCRIPTION
In order to have Google Analytics tracking on the zCore Group website,
a gtag script has been added to the following pages:
- `_layouts\careers.html`
- `_layouts\category.html`
- `_layouts\default.html`
- `_layouts\post.html`
- `_layouts\solution.html`

To test the functionality of the tracking script, load the branch and open dev tools & a network tab, then filter for:
`https://www.googletagmanager.com/gtag/js`

You should see results like those shown in the image:

![Screenshot 2025-01-27 180125](https://github.com/user-attachments/assets/be9460ef-2ec8-4be4-ba4e-725cd8ea4cfb)

