### PR TITLE
Changes to About page

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -68,7 +68,7 @@
                         <h2>zCore Group</h2>
                         <h3>Bleeding Edge Government Software Contracting.</h3>
                         <div class="about_content_block">
-                            <p>zCore Group (zCG) is consulting firm specializing in business and IT consulting. Our
+                            <p>zCore Group (zCG) is a consulting firm specializing in business and IT solutions. Our
                                 business consulting focuses on improving operational efficiency and business processes.
                                 zCG's IT consulting leverages automation in coding for our partner's solution.</p>
                         </div>


### PR DESCRIPTION
Minor change for request on language in About page:

"zCore Group is consulting firm specializing in business and IT consulting" >> "zCore Group is a consulting firm specializing in business and IT solutions"