### PR TITLE
chore: update pages artifact actions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   deploy-gh:
     environment:
@@ -43,6 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v3
+        - name: Deploy to GitHub Pages
+          id: deployment
+          uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow to use `actions/upload-pages-artifact@v3`
- upgrade deployment step to `actions/deploy-pages@v4`

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c1886fa700832faa9f0313e10a65c8