### PR TITLE
Remove dates from blog listings

### DIFF
--- a/_includes/blog_area.html
+++ b/_includes/blog_area.html
@@ -28,7 +28,6 @@
                     <div class="post_meta">
                         <ul>
                             <li><a href="#"><i class="fal fa-user"></i> {{ post.author }}</a></li>
-                            <li><a href="#"><i class="fal fa-calendar-alt"></i>  {{ post.date | date_to_long_string }}</a></li>
                             <li><a href="{{post.url}}"><i class="fal fa-reply"></i></a></li>
                         </ul>
                     </div>

--- a/_includes/blog_area_3.html
+++ b/_includes/blog_area_3.html
@@ -24,7 +24,6 @@
                             <div class="post_meta">
                                 <ul>
                                     <li><a href="#"><i class="fal fa-user"></i> {{post.author}}</a></li>
-                                    <li><a href="#"><i class="fal fa-calendar-alt"></i>  {{post.date | date_to_long_string }}</a></li>
                                 </ul>
                             </div>
                             <div class="post_text">

--- a/_includes/post_loop_one.html
+++ b/_includes/post_loop_one.html
@@ -19,7 +19,6 @@
             <div class="post_meta">
                 <ul>
                     <li><i class="fal fa-user"></i>{{post.author}}</li>
-                    <li><i class="fal fa-calendar-alt"></i>{{post.date | date_to_long_string}}</li>
                 </ul>
             </div>
         </div>

--- a/_includes/post_loop_three.html
+++ b/_includes/post_loop_three.html
@@ -19,7 +19,6 @@
             <div class="post_meta">
                 <ul>
                     <li><i class="fal fa-user"></i>{{post.author}}</li>
-                    <li><i class="fal fa-calendar-alt"></i>{{post.date | date_to_long_string}}</li>
                 </ul>
             </div>
         </div>

--- a/_includes/post_loop_two.html
+++ b/_includes/post_loop_two.html
@@ -12,11 +12,6 @@
             {% endif %}
         </div>
         <div class="blog_info">
-            <div class="post_meta">
-                <ul>
-                    <li><i class="far fa-clock"></i>{{post.date | date_to_long_string }}</li>
-                </ul>
-            </div>
             <h3><a href="{{post.url}}">{{post.title}}</a></h3>
             <p>{{post.content | truncatewords: "50" | strip_html }}</p>
         </div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -42,7 +42,6 @@
             {% endif %}
             <div class="feeds_info">
                 <h4><a href="{{post.url}}">{{post.title}}</a></h4>
-                <p><i class="far fa-clock"></i>{{post.date | date_to_long_string }}</p>
             </div>
         </div>
         {% endfor %}

--- a/_includes/solutions-sidebar.html
+++ b/_includes/solutions-sidebar.html
@@ -15,7 +15,6 @@
             {% endif %}
             <div class="feeds_info">
                 <h4><a href="{{post.url}}">{{post.title}}</a></h4>
-                <p><i class="far fa-clock"></i>{{post.date | date_to_long_string }}</p>
             </div>
         </div>
         {% assign counter = counter | plus: 1 %}

--- a/team.html
+++ b/team.html
@@ -131,7 +131,6 @@ title: "Our Team"
                             <div class="post_meta">
                                 <ul>
                                     <li><a href="#"><i class="fal fa-user"></i> {{post.author}}</a></li>
-                                    <li><a href="#"><i class="fal fa-calendar-alt"></i>  {{post.date | date_to_long_string }}</a></li>
                                 </ul>
                             </div>
                             <div class="post_text">


### PR DESCRIPTION
## Summary
- Drop visible post dates from all blog includes
- Strip dates from sidebar and team page so news items don't appear outdated

Fixes #360 