### PR TITLE
Remove 'bleeding edge' references

### DIFF
--- a/_about/about-us.md
+++ b/_about/about-us.md
@@ -1,6 +1,6 @@
 ---
 title: "zCore Group"
-description: "Bleeding Edge Government Software Contracting"
+description: "Government Software Contracting"
 extra_detail: "You need to deploy innovation at the edge of emerging technology. You need zCore."
 link: "/solutions/"
 order: 1

--- a/_action/call-to-action.md
+++ b/_action/call-to-action.md
@@ -1,5 +1,5 @@
 ---
-title: zCore Call to Action - Bleeding Edge Software
+title: zCore Call to Action - Software
 button_text: Win with Us
 button_link: #
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 
-title: "zCoreGroup - Bleeding Edge Government Software Contracting"
+title: "zCoreGroup - Government Software Contracting"
 description: >- # this means to ignore newlines until "baseurl:"
   zCore Group (zCG) is consulting firm specializing in business and IT consulting. Our business consulting focuses on improving operational efficiency and business processes. zCG's IT consulting leverages automation in coding for our partner's solution.
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -66,7 +66,7 @@
                         <span class="dot"></span>
                         <span class="about_span">About Us</span>
                         <h2>zCore Group</h2>
-                        <h3>Bleeding Edge Government Software Contracting.</h3>
+                        <h3>Government Software Contracting.</h3>
                         <div class="about_content_block">
                             <p>zCore Group (zCG) is a consulting firm specializing in business and IT solutions. Our
                                 business consulting focuses on improving operational efficiency and business processes.

--- a/about.html
+++ b/about.html
@@ -171,7 +171,7 @@ title: "About Us"
             <div class="col-lg-9">
                 <div class="call_title_3 ">
                     <span class="theme_span"></span>
-                    <h2>Bleeding Edge Software Solutions for Government</h2>
+                    <h2>Software Solutions for Government</h2>
                 </div>
             </div>
             <div class="col-lg-3">

--- a/contact.html
+++ b/contact.html
@@ -132,7 +132,7 @@ title: "Contact Us"
             <div class="col-lg-9">
                 <div class="call_title_3 ">
                     <span class="theme_span"></span>
-                    <h2>Bleeding Edge Software Solutions for Government</h2>
+                    <h2>Software Solutions for Government</h2>
                 </div>
             </div>
             <div class="col-lg-3">


### PR DESCRIPTION
## Summary
- drop 'bleeding edge' from site configuration and content

Fixes #359 